### PR TITLE
Support FCPath for reading labels and images

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ import vicar
 vic = vicar.VicarImage("path/to/file")
 ```
 
+(The file path can be any URL accepted by [`FCPath`](https://rms-filecache.readthedocs.io/en/latest/module.html#filecache.file_cache_path.FCPath).)
+
 The resulting object contains:
 
 - `vic.array`: The 3-D data array converted to native format.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,11 @@ name = "rms-vicar"
 dynamic = ["version"]
 description = "Routines for converting to and from VICAR image files"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "numpy",
     "pyparsing",
+    "rms-filecache",
     "rms-vax"
 ]
 license = {text = "Apache-2.0"}
@@ -26,7 +27,6 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Utilities",
   "License :: OSI Approved :: Apache Software License",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ myst-parser
 numpy
 pyparsing
 pytest
+rms-filecache
 rms-vax
 sphinx
 sphinxcontrib-napoleon

--- a/tests/test_vicarimage.py
+++ b/tests/test_vicarimage.py
@@ -9,6 +9,7 @@ import pathlib
 import unittest
 import sys
 from contextlib import redirect_stdout
+from filecache import FCPath
 from vicar.vicarimage import VicarImage
 from vicar.vicarlabel import VicarError
 
@@ -138,8 +139,8 @@ class Test_VicarImage(unittest.TestCase):
         vim.filepath = None
         self.assertEqual(vim.filepath, None)
         vim.filepath = str(filepath)
-        self.assertEqual(vim.filepath, filepath)
-        self.assertIsInstance(vim.filepath, pathlib.Path)
+        self.assertEqual(str(vim.filepath), str(filepath))
+        self.assertIsInstance(vim.filepath, FCPath)
 
         # binheader
         test = VicarImage(test_dir / 'C2069302_GEOMA.DAT')

--- a/tests/test_vicarimage.py
+++ b/tests/test_vicarimage.py
@@ -139,7 +139,8 @@ class Test_VicarImage(unittest.TestCase):
         vim.filepath = None
         self.assertEqual(vim.filepath, None)
         vim.filepath = str(filepath)
-        self.assertEqual(str(vim.filepath), str(filepath))
+        self.assertEqual(str(vim.filepath).replace('\\', '/'),
+                         str(filepath).replace('\\', '/'))
         self.assertIsInstance(vim.filepath, FCPath)
 
         # binheader

--- a/tests/test_vicarlabel.py
+++ b/tests/test_vicarlabel.py
@@ -305,7 +305,8 @@ class Test_VicarLabel(unittest.TestCase):
 
         altvic.filepath = str(dest)
         self.assertIsInstance(altvic.filepath, FCPath)
-        self.assertEqual(str(altvic.filepath), str(dest))
+        self.assertEqual(str(altvic.filepath).replace('\\', '/'),
+                         str(dest).replace('\\', '/'))
 
         os.remove(dest)     # delete extra file
 

--- a/tests/test_vicarlabel.py
+++ b/tests/test_vicarlabel.py
@@ -7,6 +7,7 @@ import pathlib
 import shutil
 import sys
 import unittest
+from filecache import FCPath
 from vicar.vicarlabel import VicarLabel, VicarError, _REQUIRED
 from vicar._LABEL_GRAMMAR import _LABEL_GRAMMAR
 
@@ -303,8 +304,8 @@ class Test_VicarLabel(unittest.TestCase):
         self.assertRaises(ValueError, altvic.write_label)
 
         altvic.filepath = str(dest)
-        self.assertIsInstance(altvic.filepath, pathlib.Path)
-        self.assertEqual(altvic.filepath, dest)
+        self.assertIsInstance(altvic.filepath, FCPath)
+        self.assertEqual(str(altvic.filepath), str(dest))
 
         os.remove(dest)     # delete extra file
 

--- a/vicar/vicarimage.py
+++ b/vicar/vicarimage.py
@@ -4,10 +4,11 @@
 """Class to support accessing, reading, and modifying VICAR image files."""
 
 import numpy as np
-import pathlib
 import sys
 import vax
 import warnings
+
+from filecache import FCPath
 
 try:
     from _version import __version__
@@ -111,7 +112,7 @@ class VicarImage():
         """Constructor for a VicarImage object.
 
         Parameters:
-            source (pathlib.Path, str, or VicarLabel, optional):
+            source (FCPath, Path, str, or VicarLabel, optional):
                 Source for the VicarImage based on a file path or VicarLabel; if not
                 specified (equvalent to source=None), a minimal label is created.
             array (array-like, optional):
@@ -139,7 +140,7 @@ class VicarImage():
         elif isinstance(source, VicarLabel):
             self._label = source
         else:
-            self._filepath = pathlib.Path(source)
+            self._filepath = FCPath(source)
             info = VicarImage._read_file(self.filepath, extraneous='ignore',
                                          strict=strict)
             (self._label, array1, prefix1, binheader1) = info
@@ -169,7 +170,7 @@ class VicarImage():
         """The path to the associated file.
 
         Returns:
-            pathlib.Path or None: The path to the associated file, if any.
+            FCPath or None: The path to the associated file, if any.
         """
 
         return self._filepath
@@ -179,14 +180,14 @@ class VicarImage():
         """Set the path to the associated file.
 
         Parameters:
-            value (pathlib.Path, str, or None):
+            value (FCPath, Path, str, or None):
                 The path to the associated file; None to remove a file association.
         """
 
         if value is None:
             self._filepath = None
         else:
-            self._filepath = pathlib.Path(value)
+            self._filepath = FCPath(value)
 
     @property
     def label(self):
@@ -548,7 +549,7 @@ class VicarImage():
         """VicarImage object from an existing VICAR image file.
 
         Parameters:
-            filepath (pathlib.Path or str): Path to an existing VICAR data file.
+            filepath (FCPath, Path, or str): Path to an existing VICAR data file.
 
             extraneous (str, optional):
                 How to handle the presence of extraneous bytes at the end of the file, one
@@ -601,7 +602,7 @@ class VicarImage():
         """Write the VicarImage object into a file.
 
         Parameters:
-            filepath (path.Pathlib or str, optional):
+            filepath (FCPath, Path, or str, optional):
                 Optional the path of the file to write. If not specified but this object's
                 filepath attribute is defined, it will write to this file.
         """
@@ -716,7 +717,7 @@ class VicarImage():
         data file.
 
         Parameters:
-            filepath (pathlib.Path or str): Path to an existing VICAR data file.
+            filepath (FCPath, Path, or str): Path to an existing VICAR data file.
 
             extraneous (str, optional):
                 How to handle the presence of extraneous bytes at the end of the file, one
@@ -752,7 +753,7 @@ class VicarImage():
         if extraneous not in ('ignore', 'print', 'warn', 'error', 'include'):
             raise ValueError('invalid input value for extraneous: ' + repr(extraneous))
 
-        filepath = pathlib.Path(filepath)
+        filepath = FCPath(filepath)
         with filepath.open('rb') as f:
 
             # Get the label

--- a/vicar/vicarimage.py
+++ b/vicar/vicarimage.py
@@ -618,7 +618,7 @@ class VicarImage():
         with self._filepath.open('wb') as f:
 
             labels = self._label.export(resize=True)
-            f.write(labels[0].encode('latin8'))
+            f.write(labels[0].encode('latin1'))
 
             if self._binheader is not None:
                 if isinstance(self._binheader, np.ndarray):
@@ -638,7 +638,7 @@ class VicarImage():
                 array[:,:,nbb:] = self._array.view(dtype='uint8')
                 f.write(array.data)
 
-            f.write(labels[1].encode('latin8'))
+            f.write(labels[1].encode('latin1'))
 
     def binheader_array(self, kind='', size=None):
         """The numbers embedded in a binary header.

--- a/vicar/vicarlabel.py
+++ b/vicar/vicarlabel.py
@@ -5,12 +5,12 @@
 
 import io
 import numbers
-import os
-import pathlib
 import pyparsing
 import re
 
 from collections import namedtuple
+from filecache import FCPath
+from pathlib import Path
 from vicar._LABEL_GRAMMAR import _LABEL_GRAMMAR, _NAME
 from vicar._DEFINITIONS import (_ENUMERATED_VALUES, _LBLSIZE_WIDTH, _REQUIRED,
                                 _REQUIRED_INTS, _REQUIRED_NAMES)
@@ -168,11 +168,11 @@ class VicarLabel():
         """Constructor for a VicarLabel.
 
         Parameters:
-            source (file, pathlib.Path, str, None, dict, or list):
+            source (file, FCPath, Path, str, None, dict, or list):
                 A representation of a VICAR label:
 
                 * *file*: The label string is read from the given, open file.
-                * *pathlib.Path*: The label string is read from the referenced file.
+                * *FCPath* or *Path*: The label string is read from the referenced file.
                 * *str*: First, a check is performed to see if it is path to an existing
                   file. If so, the label is read from that file; otherwise, the string is
                   itself interpreted as a VICAR label string.
@@ -330,8 +330,8 @@ class VicarLabel():
         """The file path associated with this VicarLabel.
 
         Returns:
-            pathlib.Path or None:
-                The Path if this object is associated with a file; None otherwise.
+            FCPath or None:
+                The FCPath if this object is associated with a file; None otherwise.
         """
 
         return self._filepath
@@ -341,13 +341,13 @@ class VicarLabel():
         """Set the file path associated with this VicarLabel.
 
         Parameters:
-            value (pathlib.Path or None):
-                The Path to the file associated with this object; None if this object is
+            value (FCPath or Path or None):
+                The FCPath or Path to the file associated with this object; None if this object is
                 not associated with a file.
         """
 
         if value:
-            self._filepath = pathlib.Path(value)
+            self._filepath = FCPath(value)
         else:
             self._filepath = None
 
@@ -411,11 +411,11 @@ class VicarLabel():
         """Interpret and validate a source object.
 
         Parameters:
-            source (file, pathlib.Path, str, None, dict, list, or tuple):
+            source (file, FCPath, Path, str, None, dict, list, or tuple):
                 A representation of VICAR label content:
 
                 * *file*: The label string is read from the given, open file.
-                * *pathlib.Path*: The label string is read from the referenced file.
+                * *FCPath* or *Path*: The label string is read from the referenced file.
                 * *str*: First, a check is performed to see if it is path to an existing
                   file. If so, the label is read from that file; otherwise, the string is
                   itself interpreted as a VICAR label string.
@@ -437,16 +437,16 @@ class VicarLabel():
 
             fileio (bool, optional):
                 True to allow the source to be read from a file, file path string, or
-                pathlib.Path object. In this case, the file path is returned in addition
+                FCPath or Path object. In this case, the file path is returned in addition
                 to the lists.
 
         Returns:
-            (list, list, list[, pathlib.Path or None]): A tuple containing:
+            (list, list, list[, FCPath or None]): A tuple containing:
 
             * list[str]: List of names.
             * list[int, float, str, or list]: List of values.
             * list[_ValueFormat or None]: List of formatting hints.
-            * pathlib.Path or None, optional: The pathlib.Path of the file if the label
+            * FCPath or None, optional: The FCPath of the file if the label
               was read from a file; otherwise, None. Included only if `fileio` is True.
 
         Raises:
@@ -522,14 +522,20 @@ class VicarLabel():
         if fileio:
             filepath = None
             if isinstance(source, io.IOBase):
-                filepath = pathlib.Path(source.name)
+                filepath = FCPath(source.name)
                 source = VicarLabel.read_label(source)
-            elif isinstance(source, pathlib.Path):
+            elif isinstance(source, (FCPath, Path)):
                 filepath = source
                 source = VicarLabel.read_label(source)
-            elif isinstance(source, str) and os.path.exists(source):
-                filepath = pathlib.Path(source)
-                source = VicarLabel.read_label(filepath)
+            elif isinstance(source, str):
+                filepath = FCPath(source)
+                try:
+                    exists = filepath.exists()
+                except:
+                    # Who knows what a random label string will do to FCPath!
+                    exists = False
+                if exists:
+                    source = VicarLabel.read_label(filepath)
 
         # Convert to list of tuples
         if isinstance(source, tuple):
@@ -849,11 +855,11 @@ class VicarLabel():
         """Append the additional content to the end of this label.
 
         Parameters:
-            source (file, pathlib.Path, str, None, dict, list, or tuple):
+            source (file, FCPath, Path, str, None, dict, list, or tuple):
                 A representation of VICAR label content:
 
                 * *file*: The label string is read from the given, open file.
-                * *pathlib.Path*: The label string is read from the referenced file.
+                * *FCPath* or *Path*: The label string is read from the referenced file.
                 * *str*: First, a check is performed to see if it is path to an existing
                   file. If so, the label is read from that file; otherwise, the string is
                   itself interpreted as a VICAR label string.
@@ -951,11 +957,11 @@ class VicarLabel():
         """Insert the given content into this label at the specified index.
 
         Parameters:
-            source (file, pathlib.Path, str, dict, list, or tuple):
+            source (file, FCPath, Path, str, dict, list, or tuple):
                 A representation of VICAR label content:
 
                 * *file*: The label string is read from the given, open file.
-                * *pathlib.Path*: The label string is read from the referenced file.
+                * *FCPath* or *Path*: The label string is read from the referenced file.
                 * *str*: First, a check is performed to see if it is path to an existing
                   file. If so, the label is read from that file; otherwise, the string is
                   itself interpreted as a VICAR label string.
@@ -2249,7 +2255,7 @@ class VicarLabel():
         parameter.
 
         Parameters:
-            source (str, pathlib.Path, or file):
+            source (str, FCPath, Path, or file):
                 A path to a VICAR data file or else a file object already opened for
                 binary read.
             _extra (bool, optional):
@@ -2273,73 +2279,78 @@ class VicarLabel():
         if isinstance(source, io.IOBase):
             f = source
             filepath = f.name
-            close_when_done = False
+            return VicarLabel._read_label(f, filepath,_extra)
+
+        filepath = FCPath(source)
+        with filepath.open('rb') as f:
+            return VicarLabel._read_label(f, filepath,_extra)
+
+    @staticmethod
+    def _read_label(f, filepath, _extra):
+        """Read the label from the given file.
+
+        Parameters:
+            f (file): The file to read the label from.
+            filepath (FCPath or Path): The path to the file.
+            _extra (bool): True to return any extraneous bytes from the end of the file.
+        """
+
+        # Read the beginning of the VICAR file to get the label size
+        f.seek(0)
+        snippet = f.read(40).decode('latin8')
+        match = _LBLSIZE_PATTERN.match(snippet)
+        if not match:       # pragma: no cover
+            raise VicarError('Missing LBLSIZE keyword in file ' + str(filepath))
+
+        lblsize = int(match.group(1))
+
+        # Read the top VICAR label
+        f.seek(0)
+        label = f.read(lblsize).decode('latin8')
+        label = label.partition('\0')[0]
+
+        # Parse
+        ldict = VicarLabel(label, strict=False)
+
+        # Figure out the distance to the EOL label
+        recsize = ldict['RECSIZE']
+        nlb = ldict.get('NLB', 0)
+        # N2*N3 is simpler but there are files where these values aren't right
+        if ldict['ORG'] == 'BIP':           # pragma: no cover
+            data_recs = ldict['NL'] * ldict['NS']
         else:
-            filepath = pathlib.Path(source)
-            f = filepath.open('rb')
-            close_when_done = True
+            data_recs = ldict['NL'] * ldict['NB']
+        skip = lblsize + recsize * (nlb + data_recs)
+        f.seek(skip)
 
-        try:
-            # Read the beginning of the VICAR file to get the label size
-            f.seek(0)
-            snippet = f.read(40).decode('latin8')
-            match = _LBLSIZE_PATTERN.match(snippet)
-            if not match:       # pragma: no cover
-                raise VicarError('Missing LBLSIZE keyword in file ' + str(filepath))
+        # Try to read the EOF label
+        snippet = str(f.read(40).decode('latin8'))
+        match = _LBLSIZE_PATTERN.match(snippet)
+        if match:
+            eolsize = int(match.group(1))
+            f.seek(skip)
+            eol = f.read(eolsize).decode('latin8')
+            eol = eol.partition('\0')[0]
 
-            lblsize = int(match.group(1))
+            if not label.endswith(' '):     # pragma: no cover
+                label += '  '
 
-            # Read the top VICAR label
-            f.seek(0)
-            label = f.read(lblsize).decode('latin8')
-            label = label.partition('\0')[0]
-
-            # Parse
-            ldict = VicarLabel(label, strict=False)
-
-            # Figure out the distance to the EOL label
-            recsize = ldict['RECSIZE']
-            nlb = ldict.get('NLB', 0)
-            # N2*N3 is simpler but there are files where these values aren't right
-            if ldict['ORG'] == 'BIP':           # pragma: no cover
-                data_recs = ldict['NL'] * ldict['NS']
-            else:
-                data_recs = ldict['NL'] * ldict['NB']
-            skip = lblsize + recsize * (nlb + data_recs)
+            label += eol
+        else:
             f.seek(skip)
 
-            # Try to read the EOF label
-            snippet = str(f.read(40).decode('latin8'))
-            match = _LBLSIZE_PATTERN.match(snippet)
-            if match:
-                eolsize = int(match.group(1))
-                f.seek(skip)
-                eol = f.read(eolsize).decode('latin8')
-                eol = eol.partition('\0')[0]
+        # Check for extraneous bytes
+        if _extra:
+            return (label, f.read())
 
-                if not label.endswith(' '):     # pragma: no cover
-                    label += '  '
-
-                label += eol
-            else:
-                f.seek(skip)
-
-            # Check for extraneous bytes
-            if _extra:
-                return (label, f.read())
-
-            return label
-
-        finally:
-            if close_when_done:
-                f.close()
+        return label
 
     @staticmethod
     def from_file(filepath):
         """A new VicarLabel object derived from the given VICAR data file.
 
         Parameters:
-            filepath (str or pathlib.Path): Path to a VICAR data file.
+            filepath (str or FCPath or Path): Path to a VICAR data file.
 
         Returns:
             VicarLabel: VicarLabel object read from file.
@@ -2351,7 +2362,7 @@ class VicarLabel():
         """Replace the label in the selected VICAR file with this label content.
 
         Parameters:
-            filepath (str or pathlib.Path, optional):
+            filepath (str or FCPath or Path, optional):
                 Optional path of the existing file to write. If not provided, the value of
                 this object's filepath attribute is used.
 

--- a/vicar/vicarlabel.py
+++ b/vicar/vicarlabel.py
@@ -341,8 +341,8 @@ class VicarLabel():
         """Set the file path associated with this VicarLabel.
 
         Parameters:
-            value (FCPath or Path or None):
-                The FCPath or Path to the file associated with this object; None if this
+            value (FCPath, Path, str, or None):
+                The FCPath to the file associated with this object; None if this
                 object is not associated with a file.
         """
 
@@ -2280,11 +2280,11 @@ class VicarLabel():
         if isinstance(source, io.IOBase):
             f = source
             filepath = f.name
-            return VicarLabel._read_label(f, filepath,_extra)
+            return VicarLabel._read_label(f, filepath, _extra)
 
         filepath = FCPath(source)
         with filepath.open('rb') as f:
-            return VicarLabel._read_label(f, filepath,_extra)
+            return VicarLabel._read_label(f, filepath, _extra)
 
     @staticmethod
     def _read_label(f, filepath, _extra):
@@ -2351,7 +2351,7 @@ class VicarLabel():
         """A new VicarLabel object derived from the given VICAR data file.
 
         Parameters:
-            filepath (str or FCPath or Path): Path to a VICAR data file.
+            filepath (FCPath, Path, or str): Path to a VICAR data file.
 
         Returns:
             VicarLabel: VicarLabel object read from file.
@@ -2363,7 +2363,7 @@ class VicarLabel():
         """Replace the label in the selected VICAR file with this label content.
 
         Parameters:
-            filepath (str or FCPath or Path, optional):
+            filepath (FCPath, Path, or str, optional):
                 Optional path of the existing file to write. If not provided, the value of
                 this object's filepath attribute is used.
 

--- a/vicar/vicarlabel.py
+++ b/vicar/vicarlabel.py
@@ -2046,7 +2046,7 @@ class VicarLabel():
               the specified LBLSIZE.
 
         Note:
-            The returned strings must be encoded as "latin8" bytes before writing them
+            The returned strings must be encoded as "latin1" bytes before writing them
             into a data file.
         """
 
@@ -2298,7 +2298,7 @@ class VicarLabel():
 
         # Read the beginning of the VICAR file to get the label size
         f.seek(0)
-        snippet = f.read(40).decode('latin8')
+        snippet = f.read(40).decode('latin1')
         match = _LBLSIZE_PATTERN.match(snippet)
         if not match:       # pragma: no cover
             raise VicarError('Missing LBLSIZE keyword in file ' + str(filepath))
@@ -2307,7 +2307,7 @@ class VicarLabel():
 
         # Read the top VICAR label
         f.seek(0)
-        label = f.read(lblsize).decode('latin8')
+        label = f.read(lblsize).decode('latin1')
         label = label.partition('\0')[0]
 
         # Parse
@@ -2325,12 +2325,12 @@ class VicarLabel():
         f.seek(skip)
 
         # Try to read the EOF label
-        snippet = str(f.read(40).decode('latin8'))
+        snippet = str(f.read(40).decode('latin1'))
         match = _LBLSIZE_PATTERN.match(snippet)
         if match:
             eolsize = int(match.group(1))
             f.seek(skip)
-            eol = f.read(eolsize).decode('latin8')
+            eol = f.read(eolsize).decode('latin1')
             eol = eol.partition('\0')[0]
 
             if not label.endswith(' '):     # pragma: no cover
@@ -2382,7 +2382,7 @@ class VicarLabel():
 
         with self._filepath.open('r+b') as f:
 
-            snippet = f.read(40).decode('latin8')
+            snippet = f.read(40).decode('latin1')
             match = _LBLSIZE_PATTERN.match(snippet)
             if not match:       # pragma: no cover
                 raise VicarError('Missing LBLSIZE keyword in file ' + str(self._filepath))
@@ -2393,7 +2393,7 @@ class VicarLabel():
             # Update the header
             labels = self.export(resize=False)
             f.seek(0)
-            f.write(labels[0].encode('latin8'))
+            f.write(labels[0].encode('latin1'))
 
             # Update the EOL label, possibly truncating the file
             recsize = self['RECSIZE']
@@ -2402,7 +2402,7 @@ class VicarLabel():
             n3 = self['N3']
             skip = lblsize + recsize * (nlb + n2*n3)
             f.seek(skip)
-            f.write(labels[1].encode('latin8'))
+            f.write(labels[1].encode('latin1'))
             f.truncate()
 
     ######################################################################################

--- a/vicar/vicarlabel.py
+++ b/vicar/vicarlabel.py
@@ -342,8 +342,8 @@ class VicarLabel():
 
         Parameters:
             value (FCPath or Path or None):
-                The FCPath or Path to the file associated with this object; None if this object is
-                not associated with a file.
+                The FCPath or Path to the file associated with this object; None if this
+                object is not associated with a file.
         """
 
         if value:
@@ -528,13 +528,14 @@ class VicarLabel():
                 filepath = source
                 source = VicarLabel.read_label(source)
             elif isinstance(source, str):
-                filepath = FCPath(source)
+                filepath_temp = FCPath(source)
                 try:
-                    exists = filepath.exists()
-                except:
+                    exists = filepath_temp.exists()
+                except Exception:
                     # Who knows what a random label string will do to FCPath!
                     exists = False
                 if exists:
+                    filepath = filepath_temp
                     source = VicarLabel.read_label(filepath)
 
         # Convert to list of tuples


### PR DESCRIPTION
# Fixed Issues

- Fixes #24 

# Summary of Changes

- Everywhere that a `pathlib.Path` was previously allowed, also allow an `FCPath`.

# Known Problems

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Dropped Python 3.8 from CI and project metadata; minimum Python is now 3.9.
  * Adjusted file encoding behavior to use latin1 for VICAR read/write.

* **New Features**
  * Public-facing file path handling now uses an FCPath abstraction.
  * Added runtime dependencies: rms-filecache and rms-vax.

* **Tests**
  * Updated tests to expect FCPath-based filepath values.

* **Documentation**
  * README notes that file path entries may be any URL/form accepted by the new path handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->